### PR TITLE
Verify response is actually challenge response in Source protocol

### DIFF
--- a/src/GameQ/Protocols/Source.php
+++ b/src/GameQ/Protocols/Source.php
@@ -120,7 +120,12 @@ class Source extends Protocol
     {
 
         // Skip the header
-        $challenge_buffer->skip(5);
+        $challenge_buffer->skip(4);
+
+        if ($challenge_buffer->read() !== "\x41") {
+            // Response is not a challenge response
+            return true;
+        }
 
         // Apply the challenge and return
         return $this->challengeApply($challenge_buffer->read(4));

--- a/tests/Protocols/Source.php
+++ b/tests/Protocols/Source.php
@@ -72,6 +72,27 @@ class Source extends Base
         $packets[\GameQ\Protocol::PACKET_RULES] = "\xFF\xFF\xFF\xFF\x56test";
 
         // Create a fake buffer
+        $challenge_buffer = new \GameQ\Buffer("\xFF\xFF\xFF\xFF\x41test");
+
+        // Apply the challenge
+        $this->stub->challengeParseAndApply($challenge_buffer);
+
+        $this->assertEquals($packets, $this->stub->getPacket());
+    }
+
+    /**
+     * Test that the challenge application is skipped if packet is not a challenge
+     */
+    public function testSkipChallengeApply()
+    {
+        $packets = $this->packets;
+
+        // Set what the packets should look like
+        $packets[\GameQ\Protocol::PACKET_DETAILS] = "\xFF\xFF\xFF\xFFTSource Engine Query\x00%s";
+        $packets[\GameQ\Protocol::PACKET_PLAYERS] = "\xFF\xFF\xFF\xFF\x55%s";
+        $packets[\GameQ\Protocol::PACKET_RULES] = "\xFF\xFF\xFF\xFF\x56%s";
+
+        // Create a fake buffer
         $challenge_buffer = new \GameQ\Buffer("\xFF\xFF\xFF\xFF\xFFtest");
 
         // Apply the challenge


### PR DESCRIPTION
Some games, such as DayZ, might respond to a challenge request with a packet that is not a challenge response. So we have to explicitly verify in response header that the response is a challenge response.