### PR TITLE
Refactor exceptions

### DIFF
--- a/src/GameQ/Buffer.php
+++ b/src/GameQ/Buffer.php
@@ -20,7 +20,7 @@
 
 namespace GameQ;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Class Buffer
@@ -99,13 +99,13 @@ class Buffer
     /**
      * Read from the buffer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function read(int $length = 1): string
     {
 
         if (($length + $this->index) > $this->length) {
-            throw new Exception("Unable to read length=$length from buffer.  Bad protocol format or return?");
+            throw new ProtocolException("Unable to read length=$length from buffer. Bad protocol format or return?");
         }
 
         $string = substr($this->data, $this->index, $length);
@@ -173,7 +173,7 @@ class Buffer
      *
      * If not found, return everything
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readString(string $delim = "\x00"): string
     {
@@ -198,7 +198,7 @@ class Buffer
      * @param int  $offset      Number of bits to cut off the end
      * @param bool $read_offset True if the data after the offset is to be read
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readPascalString(int $offset = 0, bool $read_offset = false): string
     {
@@ -220,7 +220,7 @@ class Buffer
      *
      * If not found, return everything
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      *
      * @todo: Check to see if this is even used anymore
      */
@@ -251,7 +251,7 @@ class Buffer
     /**
      * Read an 8-bit unsigned integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt8(): int
     {
@@ -264,7 +264,7 @@ class Buffer
     /**
      * Read and 8-bit signed integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt8Signed(): int
     {
@@ -277,7 +277,7 @@ class Buffer
     /**
      * Read a 16-bit unsigned integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt16(): int
     {
@@ -297,7 +297,7 @@ class Buffer
     /**
      * Read a 16-bit signed integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt16Signed(): int
     {
@@ -320,7 +320,7 @@ class Buffer
     /**
      * Read a 32-bit unsigned integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt32($length = 4): int
     {
@@ -353,7 +353,7 @@ class Buffer
     /**
      * Read a 32-bit signed integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt32Signed(): int
     {
@@ -376,7 +376,7 @@ class Buffer
     /**
      * Read a 64-bit unsigned integer
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function readInt64(): int
     {
@@ -415,8 +415,6 @@ class Buffer
 
     /**
      * Read a 32-bit float
-     *
-     * @throws \GameQ\Exception\Protocol
      */
     public function readFloat32(): float
     {

--- a/src/GameQ/Exception/ProtocolException.php
+++ b/src/GameQ/Exception/ProtocolException.php
@@ -21,10 +21,8 @@
 namespace GameQ\Exception;
 
 /**
- * Exception
- *
  * @author Austin Bischoff <austin@codebeard.com>
  */
-class Query extends \Exception
+class ProtocolException extends \Exception
 {
 }

--- a/src/GameQ/Exception/QueryException.php
+++ b/src/GameQ/Exception/QueryException.php
@@ -21,10 +21,8 @@
 namespace GameQ\Exception;
 
 /**
- * Exception
- *
  * @author Austin Bischoff <austin@codebeard.com>
  */
-class Server extends \Exception
+class QueryException extends \Exception
 {
 }

--- a/src/GameQ/Exception/ServerException.php
+++ b/src/GameQ/Exception/ServerException.php
@@ -21,10 +21,8 @@
 namespace GameQ\Exception;
 
 /**
- * Exception
- *
  * @author Austin Bischoff <austin@codebeard.com>
  */
-class Protocol extends \Exception
+class ServerException extends \Exception
 {
 }

--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -18,8 +18,8 @@
 
 namespace GameQ;
 
-use GameQ\Exception\Protocol as ProtocolException;
-use GameQ\Exception\Query as QueryException;
+use GameQ\Exception\ProtocolException;
+use GameQ\Exception\QueryException;
 use GameQ\Filters\Base;
 use GameQ\Query\Core;
 use GameQ\Query\Native;
@@ -87,6 +87,8 @@ class GameQ
 
     /**
      * Array of servers being queried
+     *
+     * @var Server[] $servers
      */
     protected array $servers = [];
 
@@ -286,8 +288,6 @@ class GameQ
 
         // Now we should have some information to process for each server
         foreach ($this->servers as $server) {
-            /* @var $server \GameQ\Server */
-
             // Parse the responses for this server
             $result = $this->doParseResponse($server);
 
@@ -317,8 +317,6 @@ class GameQ
 
         // Do challenge packets
         foreach ($this->servers as $server_id => $server) {
-            /* @var $server \GameQ\Server */
-
             // This protocol has a challenge packet that needs to be sent
             if ($server->protocol()->hasChallenge()) {
                 // We have a challenge, set the flag
@@ -377,7 +375,6 @@ class GameQ
                 $challenge = new Buffer(implode('', $response));
 
                 // Grab the server instance
-                /* @var $server \GameQ\Server */
                 $server = $this->servers[$server_id];
 
                 // Apply the challenge
@@ -402,7 +399,7 @@ class GameQ
 
         // Iterate over the server list
         foreach ($this->servers as $server_id => $server) {
-            /* @var $server \GameQ\Server */
+            /* @var $server Server */
 
             // Invoke the beforeSend method
             $server->protocol()->beforeSend($server);
@@ -473,7 +470,6 @@ class GameQ
             $server_id = $sockets[$socket_id]['server_id'];
 
             // Grab the server instance
-            /* @var $server \GameQ\Server */
             $server = $this->servers[$server_id];
 
             // Save the response from this packet
@@ -484,7 +480,7 @@ class GameQ
 
         // Now we need to close all the sockets
         foreach ($sockets as $socketInfo) {
-            /* @var $socket \GameQ\Query\Core */
+            /* @var $socket Core */
             $socket = $socketInfo['socket'];
 
             // Close the socket

--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -345,7 +345,7 @@ class GameQ
                 } catch (QueryException $exception) {
                     // Check to see if we are in debug, if so bubble up the exception
                     if ($this->debug) {
-                        throw new \Exception($exception->getMessage(), $exception->getCode(), $exception);
+                        throw $exception;
                     }
                 }
 
@@ -446,7 +446,7 @@ class GameQ
             } catch (QueryException $exception) {
                 // Check to see if we are in debug, if so bubble up the exception
                 if ($this->debug) {
-                    throw new \Exception($exception->getMessage(), $exception->getCode(), $exception);
+                    throw $exception;
                 }
 
                 continue;
@@ -495,7 +495,7 @@ class GameQ
     /**
      * Parse the response for a specific server
      *
-     * @throws \Exception
+     * @throws ProtocolException
      */
     protected function doParseResponse(Server $server): array
     {
@@ -516,7 +516,7 @@ class GameQ
         } catch (ProtocolException $e) {
             // Check to see if we are in debug, if so bubble up the exception
             if ($this->debug) {
-                throw new \Exception($e->getMessage(), $e->getCode(), $e);
+                throw $e;
             }
 
             // We ignore this server

--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -513,10 +513,10 @@ class GameQ
 
             // Check for online before we do anything else
             $results['gq_online'] = (count($results) > 0);
-        } catch (ProtocolException $e) {
+        } catch (ProtocolException $exception) {
             // Check to see if we are in debug, if so bubble up the exception
             if ($this->debug) {
-                throw $e;
+                throw $exception;
             }
 
             // We ignore this server

--- a/src/GameQ/Protocol.php
+++ b/src/GameQ/Protocol.php
@@ -20,6 +20,8 @@
 
 namespace GameQ;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Handles the core functionality for the protocols
  *
@@ -413,6 +415,8 @@ abstract class Protocol
 
     /**
      * Method called to process query response data.  Each extending class has to have one of these functions.
+     *
+     * @throws ProtocolException
      */
     abstract public function processResponse(): mixed;
 }

--- a/src/GameQ/Protocols/Arma3.php
+++ b/src/GameQ/Protocols/Arma3.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -100,7 +101,7 @@ class Arma3 extends Source
      * Process the rules since Arma3 changed their response for rules
      *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processRules(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Ase.php
+++ b/src/GameQ/Protocols/Ase.php
@@ -18,6 +18,7 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
@@ -89,7 +90,7 @@ class Ase extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -98,7 +99,7 @@ class Ase extends Protocol
 
         // Check for valid response
         if ($buffer->getLength() < 4) {
-            throw new \GameQ\Exception\Protocol(sprintf('%s The response from the server was empty.', __METHOD__));
+            throw new ProtocolException(sprintf('%s The response from the server was empty.', __METHOD__));
         }
 
         // Read the header
@@ -106,7 +107,7 @@ class Ase extends Protocol
 
         // Verify header
         if ($header !== 'EYE1') {
-            throw new \GameQ\Exception\Protocol(sprintf('%s The response header "%s" does not match expected "EYE1"', __METHOD__, $header));
+            throw new ProtocolException(sprintf('%s The response header "%s" does not match expected "EYE1"', __METHOD__, $header));
         }
 
         // Create a new result
@@ -141,6 +142,8 @@ class Ase extends Protocol
 
     /**
      * Handles processing the extra key/value pairs for server settings
+     *
+     * @throws ProtocolException
      */
     protected function processKeyValuePairs(Buffer $buffer, Result $result)
     {
@@ -165,6 +168,8 @@ class Ase extends Protocol
 
     /**
      * Handles processing the player and team data into a usable format
+     *
+     * @throws ProtocolException
      */
     protected function processPlayersAndTeams(Buffer $buffer, Result $result)
     {

--- a/src/GameQ/Protocols/Bf3.php
+++ b/src/GameQ/Protocols/Bf3.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Battlefield 3 Protocol Class
@@ -113,7 +113,7 @@ class Bf3 extends Protocol
      * Process the response for the StarMade server
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -160,7 +160,7 @@ class Bf3 extends Protocol
             // Check to make sure the expected length matches the real length
             // Subtract 4 for the sequence_id pulled out earlier
             if ($packetLength !== ($buffer->readInt32() - 4)) {
-                throw new Exception(__METHOD__ . " packet length does not match expected length!");
+                throw new ProtocolException(__METHOD__ . " packet length does not match expected length!");
             }
 
             // Now we need to call the proper method
@@ -179,9 +179,9 @@ class Bf3 extends Protocol
 
     /**
      * Decode the buffer into a usable format
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function decode(Buffer $buffer)
     {
@@ -205,9 +205,9 @@ class Bf3 extends Protocol
 
     /**
      * Process the server details
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -270,9 +270,9 @@ class Bf3 extends Protocol
 
     /**
      * Process the server version
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processVersion(Buffer $buffer)
     {
@@ -292,9 +292,9 @@ class Bf3 extends Protocol
 
     /**
      * Process the players
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Bf4.php
+++ b/src/GameQ/Protocols/Bf4.php
@@ -44,7 +44,6 @@ class Bf4 extends Bf3
 
     /**
      * Handle processing details since they are different than BF3
-
      *
      * @return array
      */

--- a/src/GameQ/Protocols/Bfbc2.php
+++ b/src/GameQ/Protocols/Bfbc2.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Battlefield Bad Company 2 Protocol Class
@@ -115,13 +115,10 @@ class Bfbc2 extends Protocol
      * Process the response for the StarMade server
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
-
-        //print_r($this->packets_response);
-
         // Holds the results sent back
         $results = [];
 
@@ -140,7 +137,7 @@ class Bfbc2 extends Protocol
             // Check to make sure the expected length matches the real length
             // Subtract 4 for the header burn
             if ($packetLength !== ($buffer->readInt32() - 4)) {
-                throw new Exception(__METHOD__ . " packet length does not match expected length!");
+                throw new ProtocolException(__METHOD__ . " packet length does not match expected length!");
             }
 
             // We assume the packets are coming back in the same order as sent, this maybe incorrect...
@@ -161,9 +158,9 @@ class Bfbc2 extends Protocol
 
     /**
      * Decode the buffer into a usable format
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function decode(Buffer $buffer)
     {
@@ -187,7 +184,6 @@ class Bfbc2 extends Protocol
 
     /**
      * Process the server details
-
      *
      * @return array
      */
@@ -249,7 +245,6 @@ class Bfbc2 extends Protocol
 
     /**
      * Process the server version
-
      *
      * @return array
      */
@@ -270,7 +265,6 @@ class Bfbc2 extends Protocol
 
     /**
      * Process the players
-
      *
      * @return array
      */

--- a/src/GameQ/Protocols/Cfx.php
+++ b/src/GameQ/Protocols/Cfx.php
@@ -19,7 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Result;
 use GameQ\Server;
@@ -110,7 +110,7 @@ class Cfx extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -122,7 +122,7 @@ class Cfx extends Protocol
 
         // Figure out which packet response this is
         if (empty($response_type) || !array_key_exists($response_type, $this->responses)) {
-            throw new Exception(__METHOD__ . " response type '$response_type' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '$response_type' is not valid");
         }
 
         // Offload the call

--- a/src/GameQ/Protocols/Cfxplayers.php
+++ b/src/GameQ/Protocols/Cfxplayers.php
@@ -19,7 +19,7 @@
 
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * GTA Five M Protocol Class
@@ -61,7 +61,7 @@ class Cfxplayers extends Http
     /**
      * Process the response
      *
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -75,7 +75,7 @@ class Cfxplayers extends Http
 
         // Return should be JSON, let's validate
         if (!isset($matches[0]) || ($json = json_decode($matches[0], true)) === null) {
-            throw new Exception(__METHOD__ . " JSON response from Stationeers protocol is invalid.");
+            throw new ProtocolException(__METHOD__ . " JSON response from Stationeers protocol is invalid.");
         }
 
         // Return json as it should already be well formed

--- a/src/GameQ/Protocols/Cs16.php
+++ b/src/GameQ/Protocols/Cs16.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Class Cs16
  *
@@ -45,7 +47,7 @@ class Cs16 extends Source
      * @param array $packets
      *
      * @return string
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processPackets($packet_id, array $packets = [])
     {

--- a/src/GameQ/Protocols/Cs2d.php
+++ b/src/GameQ/Protocols/Cs2d.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Counter-Strike 2d Protocol Class
@@ -100,13 +100,13 @@ class Cs2d extends Protocol
      * Process the response for the Tibia server
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
 
         // We have a merged packet, try to split it back up
-        if (count($this->packets_response) == 1) {
+        if (count($this->packets_response) === 1) {
             // Temp buffer to make string manipulation easier
             $buffer = new Buffer($this->packets_response[0]);
 
@@ -147,7 +147,7 @@ class Cs2d extends Protocol
         foreach ($packets as $header => $packetGroup) {
             // Figure out which packet response this is
             if (!array_key_exists($header, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
             }
 
             // Now we need to call the proper method
@@ -166,7 +166,7 @@ class Cs2d extends Protocol
      * Handles processing the details data into a usable format
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -200,7 +200,7 @@ class Cs2d extends Protocol
      * Handles processing the player data into a usable format
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -237,7 +237,7 @@ class Cs2d extends Protocol
      *
      * @return bool
      */
-    protected function readFlag($flags, $offset)
+    protected function readFlag($flags, $offset): bool
     {
         return (bool)($flags & (1 << $offset));
     }

--- a/src/GameQ/Protocols/Doom3.php
+++ b/src/GameQ/Protocols/Doom3.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Doom3 Protocol Class
@@ -94,7 +94,7 @@ class Doom3 extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -107,7 +107,7 @@ class Doom3 extends Protocol
         // Header
         // Figure out which packet response this is
         if (empty($header) || !array_key_exists($header, $this->responses)) {
-            throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
         }
 
         return $this->{$this->responses[$header]}($buffer);
@@ -117,6 +117,7 @@ class Doom3 extends Protocol
      * Process the status response
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processStatus(Buffer $buffer)
     {
@@ -133,6 +134,7 @@ class Doom3 extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processServerInfo(Buffer $buffer)
     {
@@ -161,6 +163,7 @@ class Doom3 extends Protocol
      * Handle processing of player data
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -171,8 +174,8 @@ class Doom3 extends Protocol
         $result = new Result();
 
         // Parse players
-        // Loop thru the buffer until we run out of data
-        while (($id = $buffer->readInt8()) != 32) {
+        // Loop through the buffer until we run out of data
+        while (($id = $buffer->readInt8()) !== 32) {
             // Add player info results
             $result->addPlayer('id', $id);
             $result->addPlayer('ping', $buffer->readInt16());

--- a/src/GameQ/Protocols/Eco.php
+++ b/src/GameQ/Protocols/Eco.php
@@ -18,7 +18,7 @@
 
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -85,7 +85,7 @@ class Eco extends Http
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -98,7 +98,7 @@ class Eco extends Http
 
         // Return should be JSON, let's validate
         if (!isset($matches[0]) || ($json = json_decode($matches[0])) === null) {
-            throw new Exception("JSON response from Eco server is invalid.");
+            throw new ProtocolException("JSON response from Eco server is invalid.");
         }
 
         $result = new Result();

--- a/src/GameQ/Protocols/Etqw.php
+++ b/src/GameQ/Protocols/Etqw.php
@@ -19,7 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Result;
 
@@ -90,7 +90,7 @@ class Etqw extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -102,7 +102,7 @@ class Etqw extends Protocol
 
         // Figure out which packet response this is
         if (!array_key_exists($response_type, $this->responses)) {
-            throw new Exception(__METHOD__ . " response type '$response_type' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '$response_type' is not valid");
         }
 
         // Offload the call
@@ -117,6 +117,7 @@ class Etqw extends Protocol
      * Handle processing the status response
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processStatus(Buffer $buffer)
     {
@@ -150,7 +151,7 @@ class Etqw extends Protocol
         $result->add('servertype', $buffer->readInt8());
 
         // 0: regular server
-        if ($result->get('servertype') == 0) {
+        if ($result->get('servertype') === 0) {
             $result->add('interested_clients', $buffer->readInt8());
         } else {
             // 1: tv server
@@ -166,6 +167,8 @@ class Etqw extends Protocol
 
     /**
      * Parse players out of the status ex response
+     *
+     * @throws ProtocolException
      */
     protected function parsePlayers(Buffer $buffer, Result $result)
     {
@@ -192,11 +195,13 @@ class Etqw extends Protocol
 
     /**
      * Handle parsing extra player data
+     *
+     * @throws ProtocolException
      */
     protected function parsePlayersExtra(Buffer $buffer, Result $result)
     {
         // Iterate over the extra player info
-        while (($id = $buffer->readInt8()) != 32) {
+        while (($id = $buffer->readInt8()) !== 32) {
             $result->addPlayer('total_xp', $buffer->readFloat32());
             $result->addPlayer('teamname', $buffer->readString());
             $result->addPlayer('total_kills', $buffer->readInt32());

--- a/src/GameQ/Protocols/Ffow.php
+++ b/src/GameQ/Protocols/Ffow.php
@@ -3,10 +3,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Frontlines Fuel of War Protocol Class
@@ -92,7 +92,7 @@ class Ffow extends Protocol
     /**
      * Parse the challenge response and apply it to all the packet types
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function challengeParseAndApply(Buffer $challenge_buffer): bool
     {
@@ -107,7 +107,7 @@ class Ffow extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -122,7 +122,7 @@ class Ffow extends Protocol
 
             // Figure out which packet response this is
             if (!array_key_exists($response_type, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '" . bin2hex($response_type) . "' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($response_type) . "' is not valid");
             }
 
             // Now we need to call the proper method
@@ -141,6 +141,7 @@ class Ffow extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processInfo(Buffer $buffer)
     {
@@ -172,6 +173,7 @@ class Ffow extends Protocol
      * Handle processing the server rules
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processRules(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Gamespy.php
+++ b/src/GameQ/Protocols/Gamespy.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * GameSpy Protocol class
@@ -62,7 +62,7 @@ class Gamespy extends Protocol
     /**
      * Process the response for this protocol
      *
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -75,7 +75,7 @@ class Gamespy extends Protocol
             if (($match = preg_match("#^(.*)\\\\queryid\\\\([^\\\\]+)(\\\\|$)#", $response, $matches)) === false
                 || $match !== 1
             ) {
-                throw new Exception(__METHOD__ . " An error occurred while parsing the packets for 'queryid'");
+                throw new ProtocolException(__METHOD__ . " An error occurred while parsing the packets for 'queryid'");
             }
 
             // Multiply so we move the decimal point out of the way, if there is one

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -18,7 +18,7 @@
 
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
@@ -101,7 +101,7 @@ class Gamespy2 extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -128,7 +128,7 @@ class Gamespy2 extends Protocol
         foreach ($packets as $header => $packetGroup) {
             // Figure out which packet response this is
             if (!array_key_exists($header, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
             }
 
             // Now we need to call the proper method
@@ -152,7 +152,7 @@ class Gamespy2 extends Protocol
 
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -177,7 +177,7 @@ class Gamespy2 extends Protocol
 
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -200,7 +200,7 @@ class Gamespy2 extends Protocol
     /**
      * Parse the player/team info returned from the player call
      *
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function parsePlayerTeam(string $dataType, Buffer $buffer, Result $result)
     {

--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -18,6 +18,7 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
@@ -218,6 +219,8 @@ class Gamespy3 extends Protocol
 
     /**
      * Handles processing the details data into a usable format
+     *
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer, Result $result): void
     {
@@ -233,6 +236,8 @@ class Gamespy3 extends Protocol
 
     /**
      * Handles processing the player and team data into a usable format
+     *
+     * @throws ProtocolException
      */
     protected function processPlayersAndTeams(Buffer $buffer, Result $result): void
     {
@@ -246,7 +251,7 @@ class Gamespy3 extends Protocol
          */
         $data = explode("\x00\x00", $buffer->getBuffer());
 
-        // By default item_group is blank, this will be set for each loop thru the data
+        // By default item_group is blank, this will be set for each loop through the data
         $item_group = '';
 
         // By default the item_type is blank, this will be set on each loop

--- a/src/GameQ/Protocols/Gtan.php
+++ b/src/GameQ/Protocols/Gtan.php
@@ -17,7 +17,7 @@
  */
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 use GameQ\Server;
 
@@ -116,7 +116,7 @@ class Gtan extends Http
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -133,7 +133,7 @@ class Gtan extends Http
 
         // Return should be JSON, let's validate
         if (!isset($matches[0]) || ($json = json_decode($matches[0])) === null) {
-            throw new Exception("JSON response from Gtan protocol is invalid.");
+            throw new ProtocolException("JSON response from Gtan protocol is invalid.");
         }
 
         $result = new Result();

--- a/src/GameQ/Protocols/Gtar.php
+++ b/src/GameQ/Protocols/Gtar.php
@@ -17,7 +17,7 @@
  */
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 use GameQ\Server;
 
@@ -110,7 +110,7 @@ class Gtar extends Http
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -127,7 +127,7 @@ class Gtar extends Http
 
         // Return should be JSON, let's validate
         if (!isset($matches[0]) || ($json = json_decode($matches[0])) === null) {
-            throw new Exception("JSON response from Gtar protocol is invalid.");
+            throw new ProtocolException("JSON response from Gtar protocol is invalid.");
         }
 
         $address = $this->realIp.':'.$this->realPortQuery;

--- a/src/GameQ/Protocols/Justcause2.php
+++ b/src/GameQ/Protocols/Justcause2.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -97,6 +98,7 @@ class Justcause2 extends Gamespy4
     /**
      * Override the parent, this protocol is returned differently
      *
+     * @throws ProtocolException
      * @see Gamespy3::processPlayersAndTeams()
      */
     protected function processPlayersAndTeams(Buffer $buffer, Result $result): void

--- a/src/GameQ/Protocols/Killingfloor.php
+++ b/src/GameQ/Protocols/Killingfloor.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -52,9 +53,9 @@ class Killingfloor extends Unreal2
 
     /**
      * Overload the default detail process since this version is different
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Lhmp.php
+++ b/src/GameQ/Protocols/Lhmp.php
@@ -21,7 +21,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Lost Heaven Protocol class
@@ -95,7 +95,7 @@ class Lhmp extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -121,7 +121,7 @@ class Lhmp extends Protocol
         foreach ($packets as $header => $packetGroup) {
             // Figure out which packet response this is
             if (!array_key_exists($header, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '$header' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '$header' is not valid");
             }
 
             // Now we need to call the proper method
@@ -144,7 +144,7 @@ class Lhmp extends Protocol
      * Handles processing the details data into a usable format
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -168,6 +168,7 @@ class Lhmp extends Protocol
      * Handles processing the player data into a usable format
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/M2mp.php
+++ b/src/GameQ/Protocols/M2mp.php
@@ -21,7 +21,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Mafia 2 Multiplayer Protocol Class
@@ -101,7 +101,7 @@ class M2mp extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -114,7 +114,7 @@ class M2mp extends Protocol
         // Header
         // Figure out which packet response this is
         if ($header !== "M2MP") {
-            throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
         }
 
         return $this->{$this->responses[$header]}($buffer);
@@ -140,6 +140,7 @@ class M2mp extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processServerInfo(Buffer $buffer)
     {
@@ -164,6 +165,7 @@ class M2mp extends Protocol
      * Handle processing of player data
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Mumble.php
+++ b/src/GameQ/Protocols/Mumble.php
@@ -20,7 +20,8 @@ namespace GameQ\Protocols;
 
 use GameQ\Protocol;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
+use JsonException;
 
 /**
  * Mumble Protocol class
@@ -100,7 +101,7 @@ class Mumble extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException|JsonException
      */
     public function processResponse(): mixed
     {
@@ -112,7 +113,7 @@ class Mumble extends Protocol
         );
 
         if (!is_array($data)) {
-            throw new Exception('Failed to decode JSON response to array');
+            throw new ProtocolException('Failed to decode JSON response to array');
         }
 
         // Set the result to a new result instance

--- a/src/GameQ/Protocols/Openttd.php
+++ b/src/GameQ/Protocols/Openttd.php
@@ -21,7 +21,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * OpenTTD Protocol Class
@@ -81,7 +81,7 @@ class Openttd extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -99,7 +99,9 @@ class Openttd extends Protocol
         // Header
         // Figure out which packet response this is
         if ($packetLength !== $length) {
-            throw new Exception(__METHOD__ . " header length '" .$length . "' does not match packet length '" . $packetLength . "'.");
+            throw new ProtocolException(
+                __METHOD__ . " header length '" .$length . "' does not match packet length '" . $packetLength . "'."
+            );
         }
 
         return $this->processServerInfo($buffer);
@@ -109,6 +111,7 @@ class Openttd extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processServerInfo(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Quake2.php
+++ b/src/GameQ/Protocols/Quake2.php
@@ -6,7 +6,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Quake2 Protocol Class
@@ -80,7 +80,7 @@ class Quake2 extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -92,7 +92,7 @@ class Quake2 extends Protocol
 
         // Figure out which packet response this is
         if (empty($header) || !array_key_exists($header, $this->responses)) {
-            throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
         }
 
         return $this->{$this->responses[$header]}($buffer);
@@ -102,6 +102,7 @@ class Quake2 extends Protocol
      * Process the status response
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processStatus(Buffer $buffer)
     {
@@ -118,6 +119,7 @@ class Quake2 extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processServerInfo(Buffer $buffer)
     {
@@ -146,6 +148,7 @@ class Quake2 extends Protocol
      * Handle processing of player data
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Quake3.php
+++ b/src/GameQ/Protocols/Quake3.php
@@ -6,7 +6,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Quake3 Protocol Class
@@ -80,7 +80,7 @@ class Quake3 extends Protocol
      * Handle response from the server
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -92,7 +92,7 @@ class Quake3 extends Protocol
 
         // Figure out which packet response this is
         if (empty($header) || !array_key_exists($header, $this->responses)) {
-            throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+            throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
         }
 
         return $this->{$this->responses[$header]}($buffer);
@@ -112,6 +112,7 @@ class Quake3 extends Protocol
      * Handle processing the server information
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processServerInfo(Buffer $buffer)
     {
@@ -137,7 +138,7 @@ class Quake3 extends Protocol
      * Handle processing of player data
      *
      * @return array
-     * @throws Exception
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -166,7 +167,7 @@ class Quake3 extends Protocol
 
             // Bad response
             if ($checkPlayerName !== '"') {
-                throw new Exception('Expected " but got ' . $checkPlayerName . ' for beginning of player name string!');
+                throw new ProtocolException('Expected " but got ' . $checkPlayerName . ' for beginning of player name string!');
             }
 
             // Add player name, encoded

--- a/src/GameQ/Protocols/Quake4.php
+++ b/src/GameQ/Protocols/Quake4.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -42,9 +43,9 @@ class Quake4 extends Doom3
 
     /**
      * Handle processing of player data
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -55,8 +56,8 @@ class Quake4 extends Doom3
         $result = new Result();
 
         // Parse players
-        // Loop thru the buffer until we run out of data
-        while (($id = $buffer->readInt8()) != 32) {
+        // Loop through the buffer until we run out of data
+        while (($id = $buffer->readInt8()) !== 32) {
             // Add player info results
             $result->addPlayer('id', $id);
             $result->addPlayer('ping', $buffer->readInt16());

--- a/src/GameQ/Protocols/Raknet.php
+++ b/src/GameQ/Protocols/Raknet.php
@@ -19,7 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Result;
 use GameQ\Server;
@@ -83,7 +83,7 @@ class Raknet extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -95,7 +95,7 @@ class Raknet extends Protocol
 
         // Check first character to make sure the header matches
         if ($header !== self::ID_UNCONNECTED_PONG) {
-            throw new Exception(sprintf(
+            throw new ProtocolException(sprintf(
                 '%s The header returned "%s" does not match the expected header of "%s"',
                 __METHOD__,
                 bin2hex($header),
@@ -114,7 +114,7 @@ class Raknet extends Protocol
 
         // Magic check fails
         if ($magicCheck !== self::OFFLINE_MESSAGE_DATA_ID) {
-            throw new Exception(sprintf(
+            throw new ProtocolException(sprintf(
                 '%s The magic value returned "%s" does not match the expected value of "%s"',
                 __METHOD__,
                 bin2hex($magicCheck),

--- a/src/GameQ/Protocols/Rust.php
+++ b/src/GameQ/Protocols/Rust.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Class Rust
@@ -38,9 +39,11 @@ class Rust extends Source
      * Longer string name of this protocol class
      */
     protected string $name_long = "Rust";
-    
+
     /**
      * Overload so we can get max players from mp of keywords and num players from cp keyword
+     *
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -49,8 +52,8 @@ class Rust extends Source
         if ($results['keywords']) {
             //get max players from mp of keywords and num players from cp keyword
             preg_match_all('/(mp|cp)([\d]+)/', $results['keywords'], $matches);
-            $results['max_players'] = intval($matches[2][0]);
-            $results['num_players'] = intval($matches[2][1]);
+            $results['max_players'] = (int)$matches[2][0];
+            $results['num_players'] = (int)$matches[2][1];
         }
 
         return $results;

--- a/src/GameQ/Protocols/Samp.php
+++ b/src/GameQ/Protocols/Samp.php
@@ -22,7 +22,7 @@ use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
 use GameQ\Server;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * San Andreas Multiplayer Protocol Class (samp)
@@ -123,7 +123,7 @@ class Samp extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -141,12 +141,12 @@ class Samp extends Protocol
 
             // Check the header, should be SAMP
             if (($header = $buffer->read(4)) !== 'SAMP') {
-                throw new Exception(__METHOD__ . " header response '$header' is not valid");
+                throw new ProtocolException(__METHOD__ . " header response '$header' is not valid");
             }
 
             // Check to make sure the server response code matches what we sent
             if ($buffer->read($serverCodeLength) !== $this->server_code) {
-                throw new Exception(__METHOD__ . " code check failed.");
+                throw new ProtocolException(__METHOD__ . " code check failed.");
             }
 
             // Figure out what packet response this is for
@@ -154,7 +154,7 @@ class Samp extends Protocol
 
             // Figure out which packet response this is
             if (!array_key_exists($response_type, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '$response_type' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '$response_type' is not valid");
             }
 
             // Now we need to call the proper method
@@ -177,7 +177,7 @@ class Samp extends Protocol
      * Handles processing the server status data
      *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processStatus(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Ship.php
+++ b/src/GameQ/Protocols/Ship.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -46,9 +47,9 @@ class Ship extends Source
      * Specific player parse for The Ship
      *
      * Player response has unknown data after the last real player
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -63,7 +64,7 @@ class Ship extends Source
         $result->add('num_players', $num_players);
 
         // No players, no work
-        if ($num_players == 0) {
+        if ($num_players === 0) {
             return $result->fetch();
         }
 

--- a/src/GameQ/Protocols/Source.php
+++ b/src/GameQ/Protocols/Source.php
@@ -19,7 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Result;
 
@@ -114,7 +114,7 @@ class Source extends Protocol
     /**
      * Parse the challenge response and apply it to all the packet types
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function challengeParseAndApply(Buffer $challenge_buffer): bool
     {
@@ -135,7 +135,7 @@ class Source extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -172,7 +172,7 @@ class Source extends Protocol
         }
 
         // Free up memory
-        unset($response, $packet_id, $buffer, $header);
+        unset($packet_id, $buffer, $header);
 
         // Now that we have the packets sorted we need to iterate and process them
         foreach ($packets as $packet_id => $packet) {
@@ -188,7 +188,7 @@ class Source extends Protocol
 
             // Figure out which packet response this is
             if (!array_key_exists($response_type, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '$response_type' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '$response_type' is not valid");
             }
 
             // Now we need to call the proper method
@@ -217,7 +217,7 @@ class Source extends Protocol
      * @param array $packets
      *
      * @return string
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processPackets($packet_id, array $packets = [])
     {
@@ -254,7 +254,7 @@ class Source extends Protocol
                 if ($packet_id & 0x80000000) {
                     // Check to see if we have Bzip2 installed
                     if (!function_exists('bzdecompress')) {
-                        throw new Exception(
+                        throw new ProtocolException(
                             'Bzip2 is not installed.  See http://www.php.net/manual/en/book.bzip2.php for more info.',
                             0
                         );
@@ -271,7 +271,7 @@ class Source extends Protocol
 
                     // Now verify the length
                     if (strlen($result) !== $packet_length) {
-                        throw new Exception(
+                        throw new ProtocolException(
                             "Checksum for compressed packet failed! Length expected: $packet_length, length
                             returned: " . strlen($result)
                         );
@@ -312,7 +312,7 @@ class Source extends Protocol
      * Handles processing the details data into a usable format
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -379,10 +379,9 @@ class Source extends Protocol
 
     /**
      * Handles processing the server details from goldsource response
-
-     *
+ *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processDetailsGoldSource(Buffer $buffer)
     {
@@ -426,6 +425,7 @@ class Source extends Protocol
      * Handles processing the player data into a usable format
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -459,6 +459,7 @@ class Source extends Protocol
      * Handles processing the rules data into a usable format
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processRules(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Starmade.php
+++ b/src/GameQ/Protocols/Starmade.php
@@ -21,7 +21,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * StarMade Protocol Class
@@ -86,7 +86,7 @@ class Starmade extends Protocol
      * Process the response for the StarMade server
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -136,10 +136,9 @@ class Starmade extends Protocol
 
     /**
      * Parse the server response parameters
-
-     *
+ *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function parseServerParameters(Buffer $buffer)
     {
@@ -200,7 +199,7 @@ class Starmade extends Protocol
                 // Array
                 case 8:
                     // Not implemented
-                    throw new Exception("StarMade array parsing is not implemented!");
+                    throw new ProtocolException("StarMade array parsing is not implemented!");
             }
         }
 

--- a/src/GameQ/Protocols/Teamspeak2.php
+++ b/src/GameQ/Protocols/Teamspeak2.php
@@ -22,7 +22,7 @@ use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
 use GameQ\Server;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Teamspeak 2 Protocol Class
@@ -100,7 +100,7 @@ class Teamspeak2 extends Protocol
     /**
      * Before we send off the queries we need to update the packets
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function beforeSend(Server $server): void
     {
@@ -109,7 +109,7 @@ class Teamspeak2 extends Protocol
         if (!isset($this->options[Server::SERVER_OPTIONS_QUERY_PORT])
             || empty($this->options[Server::SERVER_OPTIONS_QUERY_PORT])
         ) {
-            throw new Exception(__METHOD__ . " Missing required setting '" . Server::SERVER_OPTIONS_QUERY_PORT . "'.");
+            throw new ProtocolException(__METHOD__ . " Missing required setting '" . Server::SERVER_OPTIONS_QUERY_PORT . "'.");
         }
 
         // Let's loop the packets and set the proper pieces
@@ -123,7 +123,7 @@ class Teamspeak2 extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -133,7 +133,7 @@ class Teamspeak2 extends Protocol
 
         // Check the header [TS]
         if (($header = trim($buffer->readString("\n"))) !== '[TS]') {
-            throw new Exception(__METHOD__ . " Expected header '$header' does not match expected '[TS]'.");
+            throw new ProtocolException(__METHOD__ . " Expected header '$header' does not match expected '[TS]'.");
         }
 
         // Split this buffer as the data blocks are bound by "OK" and drop any empty values
@@ -180,6 +180,8 @@ class Teamspeak2 extends Protocol
 
     /**
      * Handles processing the details data into a usable format
+     *
+     * @throws ProtocolException
      */
     protected function processDetails(string $data, Result $result)
     {
@@ -206,10 +208,11 @@ class Teamspeak2 extends Protocol
 
     /**
      * Process the channel listing
+     *
+     * @throws ProtocolException
      */
     protected function processChannels(string $data, Result $result)
     {
-
         // Create a buffer
         $buffer = new Buffer($data);
 
@@ -235,10 +238,11 @@ class Teamspeak2 extends Protocol
 
     /**
      * Process the user listing
+     *
+     * @throws ProtocolException
      */
     protected function processPlayers(string $data, Result $result)
     {
-
         // Create a buffer
         $buffer = new Buffer($data);
 

--- a/src/GameQ/Protocols/Teamspeak3.php
+++ b/src/GameQ/Protocols/Teamspeak3.php
@@ -22,7 +22,7 @@ use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
 use GameQ\Server;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Teamspeak 3 Protocol Class
@@ -100,7 +100,7 @@ class Teamspeak3 extends Protocol
     /**
      * Before we send off the queries we need to update the packets
      *
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function beforeSend(Server $server): void
     {
@@ -109,7 +109,7 @@ class Teamspeak3 extends Protocol
         if (!isset($this->options[Server::SERVER_OPTIONS_QUERY_PORT])
             || empty($this->options[Server::SERVER_OPTIONS_QUERY_PORT])
         ) {
-            throw new Exception(__METHOD__ . " Missing required setting '" . Server::SERVER_OPTIONS_QUERY_PORT . "'.");
+            throw new ProtocolException(__METHOD__ . " Missing required setting '" . Server::SERVER_OPTIONS_QUERY_PORT . "'.");
         }
 
         // Let's loop the packets and set the proper pieces
@@ -123,7 +123,7 @@ class Teamspeak3 extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -133,7 +133,7 @@ class Teamspeak3 extends Protocol
 
         // Check the header TS3
         if (($header = trim($buffer->readString("\n"))) !== 'TS3') {
-            throw new Exception(__METHOD__ . " Expected header '$header' does not match expected 'TS3'.");
+            throw new ProtocolException(__METHOD__ . " Expected header '$header' does not match expected 'TS3'.");
         }
 
         // Convert all the escaped characters
@@ -212,7 +212,7 @@ class Teamspeak3 extends Protocol
         // Iterate over the items
         foreach ($items as $item) {
             // Explode and make sure we always have 2 items in the array
-            list($key, $value) = array_pad(explode('=', $item, 2), 2, '');
+            [$key, $value] = array_pad(explode('=', $item, 2), 2, '');
 
             // Convert spaces and other character changes
             $properties[$key] = $this->convertToUtf8(str_replace(
@@ -234,7 +234,6 @@ class Teamspeak3 extends Protocol
      */
     protected function processDetails(string $data, Result $result)
     {
-
         // Offload the parsing for these values
         $properties = $this->processProperties($data);
 
@@ -260,7 +259,6 @@ class Teamspeak3 extends Protocol
      */
     protected function processChannels(string $data, Result $result)
     {
-
         // We need to split the data at the pipe
         $channels = explode('|', $data);
 
@@ -283,7 +281,6 @@ class Teamspeak3 extends Protocol
      */
     protected function processPlayers(string $data, Result $result)
     {
-
         // We need to split the data at the pipe
         $players = explode('|', $data);
 

--- a/src/GameQ/Protocols/Teeworlds.php
+++ b/src/GameQ/Protocols/Teeworlds.php
@@ -21,7 +21,7 @@ namespace GameQ\Protocols;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Teeworlds Protocol class
@@ -95,7 +95,7 @@ class Teeworlds extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -112,7 +112,7 @@ class Teeworlds extends Protocol
 
             // Figure out which packet response this is
             if (!array_key_exists($header, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
             }
 
             // Now we need to call the proper method

--- a/src/GameQ/Protocols/Tibia.php
+++ b/src/GameQ/Protocols/Tibia.php
@@ -20,7 +20,7 @@ namespace GameQ\Protocols;
 
 use GameQ\Protocol;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 
 /**
  * Tibia Protocol Class
@@ -88,7 +88,7 @@ class Tibia extends Protocol
      * Process the response for the Tibia server
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -97,7 +97,7 @@ class Tibia extends Protocol
 
         // Check to make sure this is will decode into a valid XML Document
         if (($xmlDoc = @simplexml_load_string($xmlString)) === false) {
-            throw new Exception(__METHOD__ . " Unable to load XML string.");
+            throw new ProtocolException(__METHOD__ . " Unable to load XML string.");
         }
 
         // Set the result to a new result instance

--- a/src/GameQ/Protocols/Tshock.php
+++ b/src/GameQ/Protocols/Tshock.php
@@ -17,7 +17,7 @@
  */
 namespace GameQ\Protocols;
 
-use GameQ\Exception\Protocol as Exception;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -87,7 +87,7 @@ class Tshock extends Http
      * Process the response
      *
      * @return mixed
-     * @throws Exception
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -105,12 +105,12 @@ class Tshock extends Http
             512,
             JSON_THROW_ON_ERROR
         )) === null) {
-            throw new Exception("JSON response from Tshock protocol is invalid.");
+            throw new ProtocolException("JSON response from Tshock protocol is invalid.");
         }
 
         // Check the status response
         if ($json->status !== '200') {
-            throw new Exception("JSON status from Tshock protocol response was '$json->status', expected '200'.");
+            throw new ProtocolException("JSON status from Tshock protocol response was '$json->status', expected '200'.");
         }
 
         $result = new Result();

--- a/src/GameQ/Protocols/Unreal2.php
+++ b/src/GameQ/Protocols/Unreal2.php
@@ -18,10 +18,10 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Buffer;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Unreal 2 Protocol class
@@ -92,7 +92,7 @@ class Unreal2 extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -119,7 +119,7 @@ class Unreal2 extends Protocol
         foreach ($packets as $header => $packetGroup) {
             // Figure out which packet response this is
             if (!array_key_exists($header, $this->responses)) {
-                throw new Exception(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
+                throw new ProtocolException(__METHOD__ . " response type '" . bin2hex($header) . "' is not valid");
             }
 
             // Now we need to call the proper method
@@ -143,7 +143,7 @@ class Unreal2 extends Protocol
 
      *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processDetails(Buffer $buffer)
     {
@@ -167,9 +167,9 @@ class Unreal2 extends Protocol
 
     /**
      * Handles processing the player data into a usable format
-
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {
@@ -201,6 +201,7 @@ class Unreal2 extends Protocol
      * Handles processing the rules data into a usable format
      *
      * @return array
+     * @throws ProtocolException
      */
     protected function processRules(Buffer $buffer)
     {

--- a/src/GameQ/Protocols/Ventrilo.php
+++ b/src/GameQ/Protocols/Ventrilo.php
@@ -18,9 +18,9 @@
 
 namespace GameQ\Protocols;
 
+use GameQ\Exception\ProtocolException;
 use GameQ\Protocol;
 use GameQ\Result;
-use GameQ\Exception\Protocol as Exception;
 
 /**
  * Ventrilo Protocol Class
@@ -622,7 +622,7 @@ class Ventrilo extends Protocol
      * Process the response
      *
      * @return mixed
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     public function processResponse(): mixed
     {
@@ -681,7 +681,7 @@ class Ventrilo extends Protocol
             // Check to see if we have a colon, every line should
             if (($colon_pos = strpos($line, ":")) !== false && $colon_pos > 0) {
                 // Split the line into key/value pairs
-                list($key, $value) = explode(':', $line, 2);
+                [$key, $value] = explode(':', $line, 2);
 
                 // Lower the font of the key
                 $key = strtolower($key);
@@ -730,7 +730,7 @@ class Ventrilo extends Protocol
      * Decrypt the incoming packets
      *
      * @return string
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function decryptPackets(array $packets = [])
     {
@@ -753,8 +753,8 @@ class Ventrilo extends Protocol
             $a1 = $key & 0xFF;
             $a2 = $key >> 8;
 
-            if ($a1 == 0) {
-                throw new Exception(__METHOD__ . ": Header key is invalid");
+            if ($a1 === 0) {
+                throw new ProtocolException(__METHOD__ . ": Header key is invalid");
             }
 
             $table = $this->head_encrypt_table;
@@ -765,7 +765,7 @@ class Ventrilo extends Protocol
             for ($index = 1; $index <= $characterCount; $index++) {
                 $chars[$index] -= ($table[$a2] + (($index - 1) % 5)) & 0xFF;
                 $a2 = ($a2 + $a1) & 0xFF;
-                if (($index % 2) == 0) {
+                if (($index % 2) === 0) {
                     $short_array = unpack("n1", pack("C2", $chars[$index - 1], $chars[$index]));
                     $header_items[$key] = $short_array[1];
                     ++$key;
@@ -785,8 +785,8 @@ class Ventrilo extends Protocol
             ], $header_items);
 
             // Check to make sure the number of packets match
-            if ($header_items['totpck'] != count($packets)) {
-                throw new Exception(__METHOD__ . ": Too few packets received");
+            if ($header_items['totpck'] !== count($packets)) {
+                throw new ProtocolException(__METHOD__ . ": Too few packets received");
             }
 
             # Data :
@@ -795,7 +795,7 @@ class Ventrilo extends Protocol
             $a2 = $header_items['datakey'] >> 8;
 
             if ($a1 === 0) {
-                throw new Exception(__METHOD__ . ": Data key is invalid");
+                throw new ProtocolException(__METHOD__ . ": Data key is invalid");
             }
 
             $chars = unpack("C*", substr($packet, 20));

--- a/src/GameQ/Protocols/Warsow.php
+++ b/src/GameQ/Protocols/Warsow.php
@@ -19,6 +19,7 @@
 namespace GameQ\Protocols;
 
 use GameQ\Buffer;
+use GameQ\Exception\ProtocolException;
 use GameQ\Result;
 
 /**
@@ -48,7 +49,7 @@ class Warsow extends Quake3
      * Handle player info, different than quake3 base
      *
      * @return array
-     * @throws \GameQ\Exception\Protocol
+     * @throws ProtocolException
      */
     protected function processPlayers(Buffer $buffer)
     {

--- a/src/GameQ/Query/Core.php
+++ b/src/GameQ/Query/Core.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Query;
 
+use GameQ\Exception\QueryException;
+
 /**
  * Core for the query mechanisms
  *
@@ -124,6 +126,8 @@ abstract class Core
 
     /**
      * Get the socket
+     *
+     * @throws QueryException
      */
     abstract public function get(): mixed;
 
@@ -131,6 +135,7 @@ abstract class Core
      * Write data to the socket
      *
      * @return int The number of bytes written
+     * @throws QueryException
      */
     abstract public function write(string|array $data): int;
 

--- a/src/GameQ/Query/Native.php
+++ b/src/GameQ/Query/Native.php
@@ -63,8 +63,8 @@ class Native extends Core
 
             // Send the packet
             return fwrite($this->socket, $data);
-        } catch (\Exception $e) {
-            throw new QueryException($e->getMessage(), $e->getCode(), $e);
+        } catch (\Exception $exception) {
+            throw new QueryException($exception->getMessage(), $exception->getCode(), $exception);
         }
     }
 

--- a/src/GameQ/Query/Native.php
+++ b/src/GameQ/Query/Native.php
@@ -18,7 +18,7 @@
 
 namespace GameQ\Query;
 
-use GameQ\Exception\Query as Exception;
+use GameQ\Exception\QueryException;
 
 /**
  * Native way of querying servers
@@ -31,7 +31,7 @@ class Native extends Core
      * Get the current socket or create one and return
      *
      * @return mixed
-     * @throws \GameQ\Exception\Query
+     * @throws QueryException
      */
     public function get(): mixed
     {
@@ -50,7 +50,7 @@ class Native extends Core
      * @param string|array $data
      *
      * @return int The number of bytes written
-     * @throws \GameQ\Exception\Query
+     * @throws QueryException
      */
     public function write(string|array $data): int
     {
@@ -64,7 +64,7 @@ class Native extends Core
             // Send the packet
             return fwrite($this->socket, $data);
         } catch (\Exception $e) {
-            throw new Exception($e->getMessage(), $e->getCode(), $e);
+            throw new QueryException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -83,7 +83,7 @@ class Native extends Core
     /**
      * Create a new socket for this query
      *
-     * @throws \GameQ\Exception\Query
+     * @throws QueryException
      */
     protected function create(): void
     {
@@ -123,7 +123,7 @@ class Native extends Core
             $this->socket = null;
 
             // Something bad happened, throw query exception
-            throw new Exception(
+            throw new QueryException(
                 __METHOD__ . " - Error creating socket to server $this->ip:$this->port. Error: " . $errstr,
                 $errno
             );
@@ -144,7 +144,7 @@ class Native extends Core
         // Loop and pull out all the actual sockets we need to listen on
         foreach ($sockets as $socket_id => $socket_data) {
             // Get the socket
-            /* @var $socket \GameQ\Query\Core */
+            /* @var $socket Core */
             $socket = $socket_data['socket'];
 
             // Append the actual socket we are listening to

--- a/src/GameQ/Server.php
+++ b/src/GameQ/Server.php
@@ -18,7 +18,7 @@
 
 namespace GameQ;
 
-use GameQ\Exception\Server as Exception;
+use GameQ\Exception\ServerException;
 use GameQ\Query\Core;
 
 /**
@@ -83,19 +83,18 @@ class Server
     /**
      * Construct the class with the passed options
      *
-     * @throws \GameQ\Exception\Server
+     * @throws ServerException
      */
     public function __construct(array $server_info = [])
     {
-
         // Check for server type
         if (!array_key_exists(self::SERVER_TYPE, $server_info) || empty($server_info[self::SERVER_TYPE])) {
-            throw new Exception("Missing server info key '" . self::SERVER_TYPE . "'!");
+            throw new ServerException("Missing server info key '" . self::SERVER_TYPE . "'!");
         }
 
         // Check for server host
         if (!array_key_exists(self::SERVER_HOST, $server_info) || empty($server_info[self::SERVER_HOST])) {
-            throw new Exception("Missing server info key '" . self::SERVER_HOST . "'!");
+            throw new ServerException("Missing server info key '" . self::SERVER_HOST . "'!");
         }
 
         // IP address and port check
@@ -124,7 +123,7 @@ class Server
 
             $this->protocol = $class->newInstanceArgs([$this->options]);
         } catch (\ReflectionException) {
-            throw new Exception("Unable to locate Protocols class for '{$server_info[self::SERVER_TYPE]}'!");
+            throw new ServerException("Unable to locate Protocols class for '{$server_info[self::SERVER_TYPE]}'!");
         }
 
         // Check and set any server options
@@ -136,7 +135,7 @@ class Server
     /**
      * Check and set the ip address for this server
      *
-     * @throws \GameQ\Exception\Server
+     * @throws ServerException
      */
     protected function checkAndSetIpPort(string $ip_address): void
     {
@@ -157,7 +156,7 @@ class Server
                 unset($server_addr);
             } else {
                 // Just the IPv6 address, no port defined, fail
-                throw new Exception(
+                throw new ServerException(
                     "The host address '$ip_address' is missing the port.  All "
                     . "servers must have a port defined!"
                 );
@@ -165,7 +164,7 @@ class Server
 
             // Now let's validate the IPv6 value sent, remove the square brackets ([]) first
             if (!filter_var(trim($this->ip, '[]'), FILTER_VALIDATE_IP, ['flags' => FILTER_FLAG_IPV6,])) {
-                throw new Exception("The IPv6 address '$this->ip' is invalid.");
+                throw new ServerException("The IPv6 address '$this->ip' is invalid.");
             }
         } else {
             // We have IPv4 with a port defined
@@ -175,7 +174,7 @@ class Server
                 $this->port_client = (int)$addressParts[1];
             } else {
                 // No port, fail
-                throw new Exception(
+                throw new ServerException(
                     "The host address '$ip_address' is missing the port. All "
                     . "servers must have a port defined!"
                 );
@@ -189,7 +188,7 @@ class Server
                 // When gethostbyname() fails it returns the original string
                 if ($this->ip === $resolved) {
                     // so if ip and the result from gethostbyname() are equal this failed.
-                    throw new Exception("Unable to resolve the host '$this->ip' to an IP address.");
+                    throw new ServerException("Unable to resolve the host '$this->ip' to an IP address.");
                 }
 
                 $this->ip = $resolved;
@@ -331,9 +330,9 @@ class Server
     public function socketCleanse(): void
     {
 
-        // Close all of the sockets available
+        // Close all the sockets available
         foreach ($this->sockets as $socket) {
-            /* @var $socket \GameQ\Query\Core */
+            /* @var $socket Core */
             $socket->close();
         }
 

--- a/tests/Buffer.php
+++ b/tests/Buffer.php
@@ -197,7 +197,7 @@ class Buffer extends TestBase
     public function testReadException()
     {
         $this->expectException(ProtocolException::class);
-        $this->expectExceptionMessage("Unable to read length=6 from buffer.  Bad protocol format or return?");
+        $this->expectExceptionMessage("Unable to read length=6 from buffer. Bad protocol format or return?");
 
         $buffer = $this->buildBuffer("12345");
 

--- a/tests/Buffer.php
+++ b/tests/Buffer.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Buffer test class
  *
@@ -94,7 +96,7 @@ class Buffer extends TestBase
         ];
 
         // We are on 64-bit os
-        if (PHP_INT_SIZE == 8) {
+        if (PHP_INT_SIZE === 8) {
             // Add 64-bit tests
             $dataSet[] = [ 'readInt64', 'm', sprintf('%s/64bitunsigned_1.txt', $basePath), 90094348778156039 ];
             $dataSet[] = [ 'readInt64', 'm', sprintf('%s/64bitunsigned_2.txt', $basePath), 240 ];
@@ -194,7 +196,7 @@ class Buffer extends TestBase
      */
     public function testReadException()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("Unable to read length=6 from buffer.  Bad protocol format or return?");
 
         $buffer = $this->buildBuffer("12345");

--- a/tests/Protocols/Ase.php
+++ b/tests/Protocols/Ase.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Ase extends Base
 {
     /**
@@ -78,7 +80,7 @@ class Ase extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Ase::processResponse The response header \"Some\" does not match expected \"EYE1\"");
 
         // Read in a css source file
@@ -107,7 +109,7 @@ class Ase extends Base
      */
     public function testEmptyServerResponseDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Ase::processResponse The response from the server was empty.");
 
         // Should fail out

--- a/tests/Protocols/Bf3.php
+++ b/tests/Protocols/Bf3.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Bf3 extends Base
 {
     /**
@@ -64,7 +66,7 @@ class Bf3 extends Base
      */
     public function testInvalidPacketLengthDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Bf3::processResponse packet length does not match expected length!");
 
         // Read in a css source file

--- a/tests/Protocols/Bfbc2.php
+++ b/tests/Protocols/Bfbc2.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Bfbc2 extends Base
 {
     /**
@@ -64,7 +66,7 @@ class Bfbc2 extends Base
      */
     public function testInvalidPacketLengthDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Bfbc2::processResponse packet length does not match expected length!");
 
         // Read in a css source file

--- a/tests/Protocols/Cs2d.php
+++ b/tests/Protocols/Cs2d.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Cs2d extends Base
 {
     /**
@@ -79,7 +81,7 @@ class Cs2d extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Cs2d::processResponse response type '80000000' is not valid");
 
         // Read in a ut2004 source file

--- a/tests/Protocols/Etqw.php
+++ b/tests/Protocols/Etqw.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Etqw extends Base
 {
     /**
@@ -78,7 +80,7 @@ class Etqw extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Source::processResponse response type '");
 
         // Read in a css source file

--- a/tests/Protocols/Ffow.php
+++ b/tests/Protocols/Ffow.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Ffow extends Base
 {
     /**
@@ -101,7 +103,7 @@ class Ffow extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Ffow::processResponse response type 'ffffffff4802' is not valid");
 
         // Read in a ffow source file

--- a/tests/Protocols/Gamespy.php
+++ b/tests/Protocols/Gamespy.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Gamespy extends Base
 {
     /**
@@ -78,7 +80,7 @@ class Gamespy extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Gamespy::processResponse An error occurred while parsing the packets for 'queryid'");
 
         // Read in a css source file

--- a/tests/Protocols/Lhmp.php
+++ b/tests/Protocols/Lhmp.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Lhmp extends Base
 {
     /**
@@ -79,7 +81,7 @@ class Lhmp extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Lhmp::processResponse response type 'LHMPz' is not valid");
 
         // Read in a lhmp source file

--- a/tests/Protocols/Quake2.php
+++ b/tests/Protocols/Quake2.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Quake2 extends Base
 {
 
@@ -82,7 +84,7 @@ class Quake2 extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Quake2::processResponse response type 'ffffffff7072696e7473' is not valid");
 
         // Read in a quake 2 source file

--- a/tests/Protocols/Quake3.php
+++ b/tests/Protocols/Quake3.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Quake3 extends Base
 {
 
@@ -79,7 +81,7 @@ class Quake3 extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage(
             "GameQ\Protocols\Quake3::processResponse response type 'ffffffff737461747573526573706f6e736573' is not valid"
         );

--- a/tests/Protocols/Raknet.php
+++ b/tests/Protocols/Raknet.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Raknet extends Base
 {
     /**
@@ -83,7 +85,7 @@ class Raknet extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage(
             "GameQ\Protocols\Raknet::processResponse The header returned \"1d\" does not match the expected header of \"1c\""
         );
@@ -125,7 +127,7 @@ class Raknet extends Base
      */
     public function testInvalidMagicDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage(
             "GameQ\Protocols\Raknet::processResponse The magic value returned \"ffff00bc4d4350453bc2a772c2a761c2\" "
             . "does not match the expected value of \"00ffff00fefefefefdfdfdfd12345678\""

--- a/tests/Protocols/Samp.php
+++ b/tests/Protocols/Samp.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Samp extends Base
 {
     /**
@@ -63,7 +65,7 @@ class Samp extends Base
      */
     public function testPacketHeader()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Samp::processResponse header response 'SAMu' is not valid");
 
         // Read in a samp source file
@@ -81,7 +83,7 @@ class Samp extends Base
      */
     public function testServerCode()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Samp::processResponse code check failed.");
         // Read in a samp source file
         $source = file_get_contents(sprintf('%s/Providers/Samp/1_response.txt', __DIR__));
@@ -115,7 +117,7 @@ class Samp extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Samp::processResponse response type 'X' is not valid");
 
         // Read in a samp source file

--- a/tests/Protocols/Source.php
+++ b/tests/Protocols/Source.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Source extends Base
 {
     /**
@@ -123,7 +125,7 @@ class Source extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Source::processResponse response type 'X' is not valid");
 
         // Read in a css source file

--- a/tests/Protocols/Teamspeak2.php
+++ b/tests/Protocols/Teamspeak2.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Test Class for Teamspeak2
  *
@@ -68,7 +70,7 @@ class Teamspeak2 extends Base
      */
     public function testMissingQueryPort()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Teamspeak2::beforeSend Missing required setting 'query_port'.");
         $client_port = 8767;
         $query_port = 51234;
@@ -129,7 +131,7 @@ class Teamspeak2 extends Base
      */
     public function testInvalidHeader()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Teamspeak2::processResponse Expected header 'BadH' does not match expected '[TS]'.");
 
         $client_port = 8767;

--- a/tests/Protocols/Teamspeak3.php
+++ b/tests/Protocols/Teamspeak3.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Test Class for Teamspeak3
  *
@@ -68,7 +70,7 @@ class Teamspeak3 extends Base
      */
     public function testMissingQueryPort()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Teamspeak3::beforeSend Missing required setting 'query_port'.");
 
         $client_port = 9987;
@@ -128,7 +130,7 @@ class Teamspeak3 extends Base
      */
     public function testInvalidHeader()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Teamspeak3::processResponse Expected header 'So2' does not match expected 'TS3'.");
 
         $client_port = 9987;

--- a/tests/Protocols/Teeworlds.php
+++ b/tests/Protocols/Teeworlds.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 /**
  * Test Class for Teeworlds
  *
@@ -92,7 +94,7 @@ class Teeworlds extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage(
             "GameQ\Protocols\Teeworlds::processResponse response type 'ffffffffffffffffffff696e663336' is not valid"
         );

--- a/tests/Protocols/Tibia.php
+++ b/tests/Protocols/Tibia.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Tibia extends Base
 {
     /**
@@ -78,7 +80,7 @@ class Tibia extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Tibia::processResponse Unable to load XML string.");
 
         // Read in a Tibia source file

--- a/tests/Protocols/Unreal2.php
+++ b/tests/Protocols/Unreal2.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests\Protocols;
 
+use GameQ\Exception\ProtocolException;
+
 class Unreal2 extends Base
 {
     /**
@@ -80,7 +82,7 @@ class Unreal2 extends Base
      */
     public function testInvalidPacketTypeDebug()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(ProtocolException::class);
         $this->expectExceptionMessage("GameQ\Protocols\Unreal2::processResponse response type '8000000007' is not valid");
 
         // Read in a ut2004 source file

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -18,6 +18,8 @@
 
 namespace GameQ\Tests;
 
+use GameQ\Exception\ServerException;
+
 /**
  * Server testing class
  *
@@ -30,7 +32,7 @@ class Server extends TestBase
      */
     public function testMissingServerType()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("Missing server info key 'type'!");
 
         // Create a mock server should throw exception
@@ -42,7 +44,7 @@ class Server extends TestBase
      */
     public function testMissingHost()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("Missing server info key 'host'!");
 
         // Create a mock server Create a mock server should throw exception
@@ -115,7 +117,7 @@ class Server extends TestBase
      */
     public function testIpv4NoPort()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("The host address '127.0.0.1' is missing the port. All servers must have a port defined!");
 
         // Create a mock server
@@ -130,7 +132,7 @@ class Server extends TestBase
      */
     public function testIpv4UnresovlableHostname()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("Unable to resolve the host 'some.unresolable.domain' to an IP address.");
 
         // Create a mock server
@@ -159,7 +161,7 @@ class Server extends TestBase
      */
     public function testIpv6NoPort()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("The host address '[::1]' is missing the port.  All servers must have a port defined!");
 
         // Create a mock server
@@ -174,7 +176,7 @@ class Server extends TestBase
      */
     public function testIpv6Invalid()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("The IPv6 address '[:0:1]' is invalid.");
 
         // Create a mock server
@@ -189,7 +191,7 @@ class Server extends TestBase
      */
     public function testInvalidProtocol()
     {
-        $this->expectException(\GameQ\Exception\Server::class);
+        $this->expectException(ServerException::class);
         $this->expectExceptionMessage("Unable to locate Protocols class for 'doesnotexist'!");
 
         // Create a mock server


### PR DESCRIPTION
- Rename `\GameQ\Exception\Protocol` to `\GameQ\Exception\ProtocolException`
- Rename `\GameQ\Exception\Server` to `\GameQ\Exception\ServerException`
- Rename `\GameQ\Exception\Query` to `\GameQ\Exception\QueryException`
- Debug mode: Bubble up GameQ exceptions instead of wrapping them into a generic `\Exception` object
- Add missing `@throws` PHPDoc annotations